### PR TITLE
Fix surf_react adsorb spurious reactions with multiple instances (sparta/sparta#624)

### DIFF
--- a/src/surf_react_adsorb.cpp
+++ b/src/surf_react_adsorb.cpp
@@ -543,9 +543,10 @@ void SurfReactAdsorb::init()
       int m = 0;
       for (int isurf = me; isurf < nslocal; isurf += nprocs) {
 	isr = lines[isurf].isr;
-	if (surf->sr[isr] != this) continue;
-	area[m] = surf->line_size(&lines[isurf]);
-	weight[m] = 1.0;
+	if (surf->sr[isr] == this) {
+	  area[m] = surf->line_size(&lines[isurf]);
+	  weight[m] = 1.0;
+	}
 	m++;
       }
     } else {
@@ -553,9 +554,10 @@ void SurfReactAdsorb::init()
       int m = 0;
       for (int isurf = me; isurf < nslocal; isurf += nprocs) {
 	isr = tris[isurf].isr;
-	if (surf->sr[isr] != this) continue;
-	area[m] = surf->tri_size(&tris[isurf],tmp);
-	weight[m] = 1.0;
+	if (surf->sr[isr] == this) {
+	  area[m] = surf->tri_size(&tris[isurf],tmp);
+	  weight[m] = 1.0;
+	}
 	m++;
       }
     }


### PR DESCRIPTION
## Summary

Fixes the bug reported in [sparta/sparta#624](https://github.com/sparta/sparta/issues/624): with multiple `surf_react adsorb` instances assigned to different surf groups, a CD (condensation) reaction with probability **0.0** still condensed large numbers of particles, while the equivalent `surf_react global 0.0` behaved correctly.

## Root cause

In `SurfReactAdsorb::init()`, the one-time initialization of the custom per-surf `area` and `weight` values (non-distributed surfs branch) used an index `m` that was only incremented for surf elements assigned to *this* reaction model instance:

```cpp
for (int isurf = me; isurf < nslocal; isurf += nprocs) {
  isr = tris[isurf].isr;
  if (surf->sr[isr] != this) continue;   // skips m++
  area[m] = surf->tri_size(&tris[isurf],tmp);
  weight[m] = 1.0;
  m++;
}
```

`m` is an index into the *owned-surf* custom arrays (one entry per owned surf), so it must advance for every owned surf — as the distributed branch already does by indexing with `isurf` directly. With two or more adsorb instances, each instance instead wrote its values compacted at the front of the shared custom arrays:

- values landed on the wrong surf elements,
- instances overwrote each other's values, and
- trailing entries were never written and stayed at their initialized value of 0.

For a surf left with `area = weight = 0`, `react()` computes `factor = fnum * weight / area = 0/0 = NaN`, which propagates through `surf_cover`, `S_theta`, and `prob_value` (`0.0 * NaN = NaN`). Every comparison against NaN is false, so `react_prob > random_prob` fails and the `react_prob <= random_prob → continue` guard also fails — the reaction **always executes** on those surfs, regardless of its probability coefficient. This explains all the reported symptoms: spurious condensation on surfs with probability 0.0, persisting even with tiny probabilities, and disappearing when a single model is assigned to all surfs (compaction is then harmless).

## Fix

Increment `m` on every owned surf and only write `area`/`weight` when the surf belongs to this instance, matching the distributed-surfs branch.

## Verification

Minimal 2D repro (circle split into two groups, two `adsorb gs` instances: `CD S 0.5` on half the surfs, `CD S 0.0` on the rest, 500 steps):

| | prob 0.5 model | prob 0.0 model |
|---|---|---|
| before fix | 7270 reactions | **13264 reactions** |
| after fix | 7245 reactions | **0 reactions** |

Regression check: `examples/surf_react_adsorb/in.circle.gs` (single instance assigned to all surfs) produces reaction tallies identical to the shipped reference log `log.11Sep23.mpi_1.circle.gs` (26588 total, per-reaction counts all match).

https://claude.ai/code/session_01UJtcSKWBaYCvGfzHMjw3YA

---
_Generated by [Claude Code](https://claude.ai/code/session_01UJtcSKWBaYCvGfzHMjw3YA)_