### PR TITLE
Fix reaction index in surf_tally call for PS reactions

### DIFF
--- a/src/surf_react_adsorb.cpp
+++ b/src/surf_react_adsorb.cpp
@@ -2945,9 +2945,11 @@ void SurfReactAdsorb::PS_react(int isurf, int isc, double *norm)
         nsingle++;
         ireaction = nlist_gs + reactions_ps_list[i];
         tally_single[ireaction]++;
+        // surf_tally() expects a 1-indexed reaction (it decrements internally),
+        // matching the GS path which returns list[i]+1; pass ireaction+1 here
         if (ncompute_tally)
           for (m = 0; m < ncompute_tally; m++)
-            clist_active[m]->surf_tally(0.0,isurf,-1,ireaction,NULL,NULL,NULL);
+            clist_active[m]->surf_tally(0.0,isurf,-1,ireaction+1,NULL,NULL,NULL);
 
         // update tau
 


### PR DESCRIPTION
## Purpose

Fix an off-by-one error in the reaction index passed to `surf_tally()` when tallying single-event reactions in the PS (Partial Sticking) path. The `surf_tally()` function expects a 1-indexed reaction number and decrements it internally, but the PS path was passing a 0-indexed value, causing incorrect reaction tallying.

## Author(s)

_To be provided by submitter_

## Backward Compatibility

This is a bugfix that corrects incorrect behavior. The change ensures reaction tallies are attributed to the correct reaction index, which may affect output for simulations using PS reactions with tally computes. This is a correctness fix rather than a breaking change.

## Implementation Notes

The issue was in `SurfReactAdsorb::PS_react()` where `surf_tally()` was called with `ireaction` directly. The Grandcanonical (GS) path correctly passes `list[i]+1` to account for the 1-indexed expectation of `surf_tally()`. The PS path now does the same by passing `ireaction+1`.

A clarifying comment has been added to document that `surf_tally()` expects a 1-indexed reaction number and decrements it internally, matching the behavior of the GS path.

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [x] Source code follows the SPARTA formatting guidelines

## Further Information

This is a straightforward bugfix with no new features or documentation changes required. Existing tests should verify the correction.

https://claude.ai/code/session_01MarmPEtpagxMJdmCNnZvWh