### PR TITLE
Expand f_ID[*] to f_ID for per-grid/per-surf vector fixes

### DIFF
--- a/src/input.cpp
+++ b/src/input.cpp
@@ -596,13 +596,15 @@ void Input::substitute(char *&str, char *&str2, int &max, int &max2, int flag)
      p_ID[*], g_ID[*], or s_ID[*]
    fields to consider in input arg range from iarg to narg
    return new expanded # of values, and copy them w/out "*" into earg
+   f_ID[*] for a fix which produces a per-grid or per-surf vector
+     (single column) becomes the vector reference f_ID
    if any expansion occurs, earg is new allocation, must be freed by caller
    if no expansion occurs, earg just points to arg, caller need not free
 ------------------------------------------------------------------------- */
 
 int Input::expand_args(int narg, char **arg, int mode, char **&earg)
 {
-  int n,iarg,index,nlo,nhi,nmax,expandflag,icompute,ifix,icustom;
+  int n,iarg,index,nlo,nhi,nmax,expandflag,vecflag,icompute,ifix,icustom;
   char *ptr1,*ptr2,*str;
 
   ptr1 = NULL;
@@ -624,6 +626,7 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
   int newarg = 0;
   for (iarg = 0; iarg < narg; iarg++) {
     expandflag = 0;
+    vecflag = 0;
 
     if (strncmp(arg[iarg],"c_",2) == 0 ||
         strncmp(arg[iarg],"f_",2) == 0 ||
@@ -695,14 +698,16 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
                            modify->fix[ifix]->size_per_particle_cols) {
                   nmax = modify->fix[ifix]->size_per_particle_cols;
                   expandflag = 1;
-                } else if (modify->fix[ifix]->per_grid_flag &&
-                           modify->fix[ifix]->size_per_grid_cols) {
-                  nmax = modify->fix[ifix]->size_per_grid_cols;
-                  expandflag = 1;
-                } else if (modify->fix[ifix]->per_surf_flag &&
-                           modify->fix[ifix]->size_per_surf_cols) {
-                  nmax = modify->fix[ifix]->size_per_surf_cols;
-                  expandflag = 1;
+                } else if (modify->fix[ifix]->per_grid_flag) {
+                  if (modify->fix[ifix]->size_per_grid_cols) {
+                    nmax = modify->fix[ifix]->size_per_grid_cols;
+                    expandflag = 1;
+                  } else if (strcmp(ptr1+1,"*") == 0) vecflag = 1;
+                } else if (modify->fix[ifix]->per_surf_flag) {
+                  if (modify->fix[ifix]->size_per_surf_cols) {
+                    nmax = modify->fix[ifix]->size_per_surf_cols;
+                    expandflag = 1;
+                  } else if (strcmp(ptr1+1,"*") == 0) vecflag = 1;
                 }
               }
 
@@ -771,6 +776,21 @@ int Input::expand_args(int narg, char **arg, int mode, char **&earg)
         strcat(str,ptr2);
         newarg++;
       }
+
+    // strip "[*]" from a fix which produces a per-grid or per-surf vector,
+    //   e.g. f_ID[*] becomes f_ID
+
+    } else if (vecflag) {
+      if (newarg == maxarg) {
+        maxarg++;
+        earg = (char **)
+          memory->srealloc(earg,maxarg*sizeof(char *),"input:earg");
+      }
+      n = ptr1 - arg[iarg] + 1;
+      str = earg[newarg] = new char[n];
+      strncpy(str,arg[iarg],n-1);
+      str[n-1] = '\0';
+      newarg++;
 
     } else {
       if (newarg == maxarg) {


### PR DESCRIPTION
## Summary

Alternative fix for sparta/sparta#614, intended to replace sparta/sparta#621.

With a single species, `dump grid` expanded `c_n[*]` to `c_n[1]` but left `f_n[*]` literal in the dump column header. Root cause: `Input::expand_args()` only expanded `[*]` when the fix's `size_per_grid_cols`/`size_per_surf_cols` was nonzero, but `fix ave/grid` (and `ave/surf`) follow the vector convention and set it to 0 for a single value, while `compute grid` always has at least one column. Output data was unaffected because `atoi("*")` is 0, which routes to vector access — only the label was wrong.

## Why not the approach in sparta/sparta#621

PR 621 expands `f_ID[*]` to `f_ID[1]` and normalizes `argindex` 1→0 in `dump_grid.cpp`/`dump_surf.cpp`. But `expand_args()` is shared, and the other consumers were not patched, so `f_ID[*]` referencing a single-value fix would newly hard-error in:

- `compute reduce` (compute_reduce.cpp:279, 292)
- `fix ave/grid` with a fix as input (fix_ave_grid.cpp:177)
- `fix ave/surf` with a fix as input (fix_ave_surf.cpp:169)
- `fix ave/histo` (fix_ave_histo.cpp:349)
- `compute lambda/grid` nrho argument (compute_lambda_grid.cpp:256)

That's the exact usage pattern motivating the issue (writing `[*]` so a script works for any number of species), so those would be regressions for previously-working single-species scripts.

## This approach

Expand `f_ID[*]` to the bare vector reference `f_ID` when the fix produces a per-grid or per-surf vector. Every consumer of `expand_args()` already accepts a plain `f_ID` as vector access, so no per-consumer normalization is needed anywhere — only `input.cpp` changes. The stripping is restricted to brackets containing exactly `*`, so malformed ranges like `f_ID[2*]` on a vector still fail downstream as before.

The single-species dump header becomes `c_n[1] f_n` rather than the `c_n[1] f_n[1]` suggested in the issue, but `f_n` is the canonical reference for a vector quantity and is consistent with how the value must be referenced elsewhere (e.g. in stats or variables).

## Testing

Built `make serial` and ran a 2d circle-flow deck with `compute grid`, `fix ave/grid`, `fix ave/surf`, `dump grid`, and `dump surf`, all using `[*]`:

- **Single species:** `dump grid` header is `id c_n[1] f_aven` (previously `id c_n[1] f_aven[*]`); `dump surf` header is `id f_aves`. Averaged data matches the instantaneous compute values.
- **Two species:** unchanged behavior — `id c_n[1] c_n[2] f_aven[1] f_aven[2]`.
- **Regression checks (single species):** `compute reduce ave f_aven[*]`, `fix ave/grid ... f_aven[*]`, and `compute lambda/grid f_aven[*] NULL knall` all parse and run correctly (each of these errors out with the PR 621 approach).

https://claude.ai/code/session_015o4xLwaUTPWjtP9et2WVnv

---
_Generated by [Claude Code](https://claude.ai/code/session_015o4xLwaUTPWjtP9et2WVnv)_