### PR TITLE
Fix KOKKOS shared library build by forcing position-independent code

### DIFF
--- a/cmake/CMakeLists.txt
+++ b/cmake/CMakeLists.txt
@@ -103,6 +103,8 @@ set(TARGET_SPARTA spa_${SPARTA_MACHINE})
 
 set(TARGET_SPARTA_LIB sparta_${SPARTA_MACHINE})
 if(BUILD_SHARED_LIBS)
+  # Force PIC so intermediate static package libs link into the shared libsparta
+  set(CMAKE_POSITION_INDEPENDENT_CODE ON)
   set(TARGET_SPARTA_LIB_LINK "libsparta${CMAKE_SHARED_LIBRARY_SUFFIX}")
   set(TARGET_SPARTA_LIB_NAME
       "libsparta_${SPARTA_MACHINE}${CMAKE_SHARED_LIBRARY_SUFFIX}")


### PR DESCRIPTION
## Summary

Building the KOKKOS package as a shared library (`-DBUILD_SHARED_LIBS=ON -DPKG_KOKKOS=ON`) fails at link time:

```
/usr/bin/ld: KOKKOS/libpkg_kokkos.a(collide_vss_kokkos.cpp.o): relocation R_X86_64_TPOFF32
  against symbol `..._t_tracking_enabled' can not be used when making a shared object;
  recompile with -fPIC
/usr/bin/ld: failed to set dynamic section sizes: bad value
```

This is related to the build trouble reported in sparta/sparta#349.

## Root cause

`pkg_kokkos` is built as a `STATIC` library (`src/KOKKOS/CMakeLists.txt`) and then linked into the shared `libsparta`. CMake only auto-applies position-independent code to shared targets, so the static package objects come out non-PIC and the final shared-object link fails on Kokkos thread-local symbols. Builds that pass `-DCMAKE_CXX_FLAGS="-fPIC ..."` by hand happen to work, masking the underlying bug; a fresh shared build without that flag breaks.

## Fix

Set `CMAKE_POSITION_INDEPENDENT_CODE ON` inside the `BUILD_SHARED_LIBS` branch of `cmake/CMakeLists.txt`. This makes every intermediate static library position-independent automatically, with no need to pass `-fPIC` manually.

## Verification

Reconfigured and built with `-DBUILD_SHARED_LIBS=ON -DPKG_KOKKOS=ON` and **no** manual `-fPIC`:

- Configure: success
- Build: 100%, no relocation errors
- Produced a working `libsparta_kktest.so` and a `spa_kktest` executable that runs

https://claude.ai/code/session_01BTRhYQH4cUgJfkihByboS1

---
_Generated by [Claude Code](https://claude.ai/code/session_01BTRhYQH4cUgJfkihByboS1)_