### PR TITLE
Run KOKKOS regression tests in CI with "-k on -sf kk"

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -8,7 +8,9 @@ on:
 
 # Define jobs: mpi, mpi-stubs-fft, mpi-stubs-kokkos-exact-fft, and bigbig
 # Each jobs runs on ubuntu-22.04 and uses the cmake build system
-# All jobs except for bigbig and mpi-stubs-kokkos-exact-fft run ctest
+# All jobs except for bigbig run ctest. The mpi-stubs-kokkos-exact-fft job runs
+# the regression tests under KOKKOS ("-k on -sf kk") using the Serial backend
+# and SPARTA_KOKKOS_EXACT so results match the non-KOKKOS gold-standard logs.
 jobs:
   mpi:
     runs-on: ubuntu-22.04
@@ -80,33 +82,41 @@ jobs:
     - uses: actions/checkout@v4
 
     - name: Configure
+      # Build the KOKKOS package with the Serial backend and SPARTA_KOKKOS_EXACT
+      # so that KOKKOS reproduces the non-KOKKOS results exactly. This allows the
+      # KOKKOS build to be regression tested against the existing (non-KOKKOS)
+      # gold-standard log files. SPARTA_SPA_ARGS passes the KOKKOS command-line
+      # args ("-k on -sf kk") to the sparta binary for every test.
       run: |
         mkdir build
         cd build
         cmake -C ../cmake/presets/serial.cmake \
           -DSPARTA_ENABLE_TESTING=ON \
-          -DSPARTA_DEFAULT_CXX_COMPILE_FLAGS='-DSPARTA_KOKKOS_EXACT' \
+          -DSPARTA_KOKKOS_EXACT=ON \
           -DPKG_KOKKOS=ON \
+          -DKokkos_ENABLE_SERIAL=ON \
+          -DKokkos_ENABLE_OPENMP=OFF \
           -DPKG_FFT=ON \
           -DPKG_PYTHON=ON \
+          -DSPARTA_SPA_ARGS='-k on -sf kk' \
           ../cmake
 
     - name: Build
       run: cd build; make -j4
 
-#    - name: Test
-#      run: |
-#        cd build
-#        find -name 'log.archive*'
-#        sudo rm /bin/sh
-#        sudo ln -s /bin/bash /bin/sh
-#        ctest --output-on-failure -j4
+    - name: Test
+      run: |
+        cd build
+        find -name 'log.archive*'
+        sudo rm /bin/sh
+        sudo ln -s /bin/bash /bin/sh
+        ctest --output-on-failure -j4
 
-    #- uses: actions/upload-artifact@v4
-    #  if: '!cancelled()'
-    #  with:
-    #    name: 'mpi-stubs-kokkos-exact-fft-Artifacts'
-    #    path: 'build/examples/'
+    - uses: actions/upload-artifact@v4
+      if: always()
+      with:
+        name: 'mpi-stubs-kokkos-exact-fft-Artifacts'
+        path: 'build/examples/'
   bigbig:
     runs-on: ubuntu-22.04
     steps:

--- a/cmake/common/process/sparta_build_options.cmake
+++ b/cmake/common/process/sparta_build_options.cmake
@@ -200,6 +200,13 @@ endif()
   list(APPEND TARGET_SPARTA_PKGS ${TARGET_SPARTA_PKG_KOKKOS})
   set(SPARTA_DEFAULT_CXX_COMPILE_FLAGS -DSPARTA_KOKKOS
                                        ${SPARTA_DEFAULT_CXX_COMPILE_FLAGS})
+  # SPARTA_KOKKOS_EXACT makes the KOKKOS package reproduce non-KOKKOS results
+  # exactly, which allows the KOKKOS build to be regression tested against the
+  # existing (non-KOKKOS) gold-standard log files.
+  if(SPARTA_KOKKOS_EXACT)
+    set(SPARTA_DEFAULT_CXX_COMPILE_FLAGS -DSPARTA_KOKKOS_EXACT
+                                         ${SPARTA_DEFAULT_CXX_COMPILE_FLAGS})
+  endif()
   # PKG_KOKKOS depends on BUILD_KOKKOS
   set(BUILD_KOKKOS ON)
 endif()

--- a/cmake/common/set/sparta_cmake_defaults.cmake
+++ b/cmake/common/set/sparta_cmake_defaults.cmake
@@ -67,6 +67,40 @@ if(SPARTA_ENABLE_TESTING)
       "in.custom.step.set.restart" # Failing
   )
 
+  # When running the KOKKOS regression tests (SPARTA_KOKKOS_EXACT, run with
+  # "-k on -sf kk"), skip the inputs that use features which are not yet
+  # KOKKOS-enabled and would error out at run time. These tests still run in
+  # the non-KOKKOS configurations.
+  if(SPARTA_KOKKOS_EXACT)
+    list(APPEND SPARTA_DISABLED_TESTS
+        # fix ave/grid for grid/surf inputs not yet supported in KOKKOS
+        "in.ablation.2d"
+        "in.ablation.3d"
+        # surf_collide adiabatic/cll/td/impulsive styles not KOKKOS-enabled
+        "in.beam.adiabatic"
+        "in.beam.cll"
+        "in.beam.impulsive"
+        "in.beam.td"
+        "in.circle.adiabatic"
+        "in.circle.cll"
+        "in.circle.impulsive"
+        "in.circle.td"
+        # surf_react gs/ps styles use a non-KOKKOS-enabled surf_collide method
+        "in.beam.face.gs"
+        "in.beam.face.gs_ps"
+        "in.beam.face.ps"
+        "in.beam.surf.gs"
+        "in.beam.surf.gs_ps"
+        "in.beam.surf.ps"
+        "in.circle.gs"
+        "in.circle.gs_ps"
+        "in.circle.ps"
+        # external field fix not KOKKOS-enabled
+        "in.bfield"
+        "in.bfield.grid"
+    )
+  endif()
+
   list(APPEND __DEFAULT_MPI_RANKS "1")
   list(APPEND __DEFAULT_MPI_RANKS "4")
 endif()

--- a/cmake/common/set/sparta_options.cmake
+++ b/cmake/common/set/sparta_options.cmake
@@ -82,6 +82,12 @@ sparta_option(SPARTA_ENABLE_TESTING "Enable sparta testing. Default: OFF" OFF
               SPARTA_EXTRA_OPTIONS_LIST)
 
 sparta_option(
+  SPARTA_KOKKOS_EXACT
+  "Make the KOKKOS package reproduce non-KOKKOS results exactly (for regression testing). Requires PKG_KOKKOS. Default: OFF"
+  OFF
+  SPARTA_EXTRA_OPTIONS_LIST)
+
+sparta_option(
   SPARTA_DSMC_TESTING_PATH "Enable sparta dsmc_testing. Default: OFF" OFF
   SPARTA_EXTRA_OPTIONS_LIST)
 


### PR DESCRIPTION
## Problem

The `mpi-stubs-kokkos-exact-fft` CI job only **compiled** the KOKKOS package — its `Test` step was commented out — because there was no clean way to pass KOKKOS's runtime command-line args (`-k on -sf kk`) into the regression tests. As a result, the KOKKOS code paths were never actually exercised in CI.

## Solution

The test harness already appends `SPARTA_SPA_ARGS` to the sparta command line, which is the hook for the KOKKOS args. This PR wires that up and makes the KOKKOS build reproduce the non-KOKKOS gold-standard logs:

- **`SPARTA_KOKKOS_EXACT` is now a first-class CMake option** (`cmake/common/set/sparta_options.cmake` + `cmake/common/process/sparta_build_options.cmake`) that injects the `-DSPARTA_KOKKOS_EXACT` macro, instead of smuggling it through a raw `SPARTA_DEFAULT_CXX_COMPILE_FLAGS` string. Combined with the Kokkos **Serial** backend, this makes KOKKOS reproduce the non-KOKKOS results exactly, so the KOKKOS build can be regression tested against the existing (non-KOKKOS) gold-standard log files.
- **The workflow passes `-DSPARTA_SPA_ARGS='-k on -sf kk'`** so the KOKKOS args reach the sparta binary for every test, and builds with `Kokkos_ENABLE_SERIAL=ON` / `Kokkos_ENABLE_OPENMP=OFF` (the Serial backend is what matches the CPU logs deterministically).
- **A KOKKOS-incompatible test skip-list**, gated on `SPARTA_KOKKOS_EXACT` (`cmake/common/set/sparta_cmake_defaults.cmake`), excludes the 21 inputs that use features not yet KOKKOS-enabled and would otherwise error out at runtime:
  - `fix ave/grid` for grid/surf inputs (`in.ablation.2d`, `in.ablation.3d`)
  - non-KOKKOS `surf_collide` styles — adiabatic/cll/td/impulsive (`in.beam.*`, `in.circle.*`)
  - `surf_react` gs/ps styles that use a non-KOKKOS-enabled surf_collide method (`in.beam.face.*`, `in.beam.surf.*`, `in.circle.gs*`/`ps`)
  - external field fix (`in.bfield`, `in.bfield.grid`)

  These tests still run in the non-KOKKOS configurations.
- **Enabled the `Test` step (ctest) and artifact upload** for the KOKKOS job.

## Verification

Built and ran the full suite locally to confirm correctness:

- Confirmed the Serial backend is active and the `-DSPARTA_KOKKOS_EXACT` macro reaches the KOKKOS object files.
- For every test that produces numerical output, **KOKKOS results are byte-for-byte identical to non-KOKKOS** — the EXACT flag works as intended.
- Ran the full KOKKOS suite (74 tests after exclusions) **and** a non-KOKKOS baseline built with the same compiler. The KOKKOS run's failures are a **strict subset** of the baseline's — i.e. **KOKKOS introduces zero new failures**.
- The residual failures seen locally are pre-existing gold-standard mismatches caused by the local toolchain (GCC 13) vs CI's GCC 11; they fail identically in the non-KOKKOS build. Since the existing non-KOKKOS CI jobs are green on GCC 11 and KOKKOS reproduces them exactly, the KOKKOS job is expected to be green in CI.

## Note

The regression job uses the Kokkos **Serial** backend because it is the only one that matches the CPU logs deterministically. The **OpenMP** threading path cannot be regression tested against the existing logs (reduction-order nondeterminism); a build-and-smoke-run OpenMP job could be added separately if desired.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01MmoABHpFYbi5rYrb4ZGomw)_