### PR TITLE
Fix segfault in surf_collide CUSTOM per-surf temperature (issue #641)

### DIFF
--- a/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
+++ b/src/KOKKOS/surf_collide_diffuse_kokkos.cpp
@@ -211,8 +211,12 @@ void SurfCollideDiffuseKokkos::dynamic()
 
     if (surf->estatus[tindex_custom] == 0) surf->spread_custom(tindex_custom);
 
-    h_edvec_local[tindex_custom].k_view.sync_device();
-    d_t_persurf = h_edvec_local[tindex_custom].k_view.view_device();
+    // edvec_local is indexed by the per-type slot ewhich[tindex_custom],
+    //  not by the global custom index tindex_custom (see Surf::add_custom)
+
+    int ewhich = surf->ewhich[tindex_custom];
+    h_edvec_local[ewhich].k_view.sync_device();
+    d_t_persurf = h_edvec_local[ewhich].k_view.view_device();
   }
 }
 

--- a/src/surf_collide.cpp
+++ b/src/surf_collide.cpp
@@ -230,7 +230,11 @@ void SurfCollide::dynamic()
     //   surfs are distributed and load balance/adaptation took place
 
     if (surf->estatus[tindex_custom] == 0) surf->spread_custom(tindex_custom);
-    t_persurf = surf->edvec_local[tindex_custom];
+
+    // edvec_local is indexed by the per-type slot ewhich[tindex_custom],
+    //  not by the global custom index tindex_custom (see Surf::add_custom)
+
+    t_persurf = surf->edvec_local[surf->ewhich[tindex_custom]];
   }
 }
 


### PR DESCRIPTION
## Purpose

Fixes #641.

`surf_collide diffuse s_<custom>` (a per-surf diffuse temperature read from a custom attribute) segfaults on the first particle–surface collision when the custom temperature attribute is **not the first double-vector custom attribute**. This is exactly what happens when `surf_react adsorb` is also active, because adsorb creates the `area` and `weight` double-vector custom attributes.

**Root cause.** `SurfCollide::dynamic()` cached the per-surf temperature pointer using the wrong index:

```cpp
t_persurf = surf->edvec_local[tindex_custom];          // BUG
```

`tindex_custom` is the *global* custom-attribute index (index into `etype`/`esize`/`estatus`/`ewhich`), but `edvec_local` is indexed by the *per-type slot* `ewhich[tindex_custom]` — the same convention used everywhere else in the code (`surf_react_adsorb.cpp`, `fix_emit_surf.cpp`, `write_surf.cpp`). The two indices coincide only when the temperature attribute is the first double-vector custom attribute, so the bundled reproducer (which creates `tsurf` first) does not crash. When another double-vector custom attribute is created first — e.g. adsorb's `area`/`weight` — `edvec_local[tindex_custom]` reads the wrong slot or out of bounds, leaving `t_persurf` pointing at garbage. The next collision dereferences it (`tsurf = t_persurf[isurf]`) and segfaults.

This is a missing-`ewhich`-indirection bug, in the same class as the previously fixed `6fcdac6` (per-surf area/weight indexing with multiple adsorb instances).

## Author(s)

Stan Moore (Sandia National Laboratories)

## Backward Compatibility

Fully backward compatible. The change only corrects an array index; for the common case where the temperature attribute is the first double-vector custom attribute the corrected index is identical to the old one, so existing inputs produce bit-for-bit identical results.

## Implementation Notes

Two one-line fixes (plus explanatory comments), correcting the index from `tindex_custom` to `ewhich[tindex_custom]`:

- `src/surf_collide.cpp` — `SurfCollide::dynamic()`. This is the root fix; all four CPU collide styles that read `t_persurf` (`diffuse`, `cll`, `impulsive`, `td`) route through this single method, so all are corrected at once.
- `src/KOKKOS/surf_collide_diffuse_kokkos.cpp` — `SurfCollideDiffuseKokkos::dynamic()` had the identical defect. KOKKOS only provides the `diffuse` style with per-surf (CUSTOM) temperature, so this is the only KOKKOS instance.

A full codebase audit of all `e{i,d}{vec,array}[...]` accesses confirmed these were the only two sites missing the `ewhich[]` indirection; every other indexed access is a legitimate per-type loop.

**Correctness verification:**
- Reproduced the crash on a stock build with `gdb`: SIGSEGV at `surf_collide_diffuse.cpp` `tsurf = t_persurf[isurf]` on the first collision, with `tmode=CUSTOM`. Confirmed `t_persurf = edvec_local[tindex_custom]` was an out-of-bounds read returning a garbage pointer, while `edvec_local[ewhich[tindex_custom]]` was valid.
- After the CPU fix, the reproducer (and a `cll` variant) run cleanly.
- The KOKKOS fix was verified the same way: with the fix reverted, a KOKKOS-runnable variant of the reproducer segfaults; with the fix, it runs cleanly.
- **Bit-for-bit agreement** between the non-KOKKOS CPU build and the KOKKOS build (Serial backend, compiled with `-DSPARTA_KOKKOS_EXACT`) was confirmed on the reproducer variant and on the existing `examples/custom/in.custom.circle.set` and `in.custom.circle.set.fix` decks (identical stats output, differing only in wall-clock timing columns).

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included (no doc change needed — internal bugfix)
- [x] One or more example input decks are included (existing `examples/custom` decks exercise the fixed code path)
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

The crash requires `surf_collide <id> diffuse s_<custom>` together with another double-vector custom attribute created before the temperature attribute (e.g. via `surf_react adsorb`, which creates `area`/`weight`). A constant scattering temperature (`surf_collide <id> diffuse 300.0`) on the same setup is unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01G6p7cvEdY1TnjQZ6ePtyb9)_