### PR TITLE
Fix INT custom/cellID attributes written as 0 in dump surf/grid/particle

### DIFF
--- a/src/dump_grid.cpp
+++ b/src/dump_grid.cpp
@@ -803,14 +803,18 @@ void DumpGrid::pack_custom(int n)
     if (grid->esize[index] == 0) {
       int *vector = grid->eivec[grid->ewhich[index]];
       for (int i = 0; i < ncpart; i++) {
-        buf[n] = vector[cpart[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[cpart[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = grid->eiarray[grid->ewhich[index]];
       for (int i = 0; i < ncpart; i++) {
-        buf[n] = array[cpart[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[cpart[i]][icol]).d;
         n += size_one;
       }
     }

--- a/src/dump_particle.cpp
+++ b/src/dump_particle.cpp
@@ -1263,14 +1263,18 @@ void DumpParticle::pack_custom(int n)
     if (particle->esize[index] == 0) {
       int *vector = particle->eivec[particle->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = vector[clist[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[clist[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = particle->eiarray[particle->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = array[clist[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[clist[i]][icol]).d;
         n += size_one;
       }
     }
@@ -1337,13 +1341,14 @@ void DumpParticle::pack_cellid(int n)
   Particle::OnePart *particles = particle->particles;
   Grid::ChildCell *cells = grid->cells;
 
-  // NOTE: cellint (bigint) won't fit in double in some cases
-
   int icell;
 
   for (int i = 0; i < nchoose; i++) {
     icell = particles[clist[i]].icell;
-    buf[n] = cells[icell].id;
+    // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+    // the cellid column via ubuf(buf[m]).i (vtype INT/BIGINT). Numeric storage
+    // printed 0/garbage and could not hold a cellint that overflows a double.
+    buf[n] = ubuf(cells[icell].id).d;
     n += size_one;
   }
 }

--- a/src/dump_surf.cpp
+++ b/src/dump_surf.cpp
@@ -817,14 +817,18 @@ void DumpSurf::pack_custom(int n)
     if (surf->esize[index] == 0) {
       int *vector = surf->eivec[surf->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = vector[clocal[i]];
+        // store bit-punned (ubuf), NOT numeric: write_text/write_binary decode
+        // INT columns via ubuf(buf[m]).i. Numeric storage made every INT
+        // custom attribute print as 0 (low 32 bits of IEEE-754 double).
+        buf[n] = ubuf(vector[clocal[i]]).d;
         n += size_one;
       }
     } else {
       int icol = argindex[n]-1;
       int **array = surf->eiarray[surf->ewhich[index]];
       for (int i = 0; i < nchoose; i++) {
-        buf[n] = array[clocal[i]][icol];
+        // see comment above: bit-punned encoding required for INT decode
+        buf[n] = ubuf(array[clocal[i]][icol]).d;
         n += size_one;
       }
     }


### PR DESCRIPTION
## Purpose

Fixes the bug reported in `dump surf` where **integer custom per-surf attributes are always written as `0`** (`double` attributes are fine). See sparta/sparta#640.

The dump buffer is a `double *`. Integer columns are encoded by *bit-reinterpretation* (`ubuf`): `write_text`/`write_binary` decode them with `(int) ubuf(buf[m]).i`, and `vtype` for a custom attribute is set to its `etype` (`INT`). But `pack_custom` was storing the value *numerically* (`buf[n] = vector[i]`). The low 32 bits of an IEEE‑754 double holding a small integer are zero, so every `INT` custom attribute decoded back to `0`. `DOUBLE` attributes are decoded numerically and were unaffected; `pack_id` already used the correct `ubuf(...).d` convention.

While fixing `dump surf`, I swept all dump styles for the same bug class (integer `vtype` field stored numerically instead of bit-punned) and found the identical defect in:

- `DumpSurf::pack_custom` — INT custom per-surf attributes (the reported bug)
- `DumpGrid::pack_custom` — INT custom per-grid attributes
- `DumpParticle::pack_custom` — INT custom per-particle attributes
- `DumpParticle::pack_cellid` — the `cellID` column (also could not represent a `cellint` that overflows a double)

All other integer fields (`id`, `type`, `proc`, `split`) already used `ubuf(...).d` correctly, and `dump tally` / `dump image` / `dump movie` decode consistently with the now-fixed pack methods.

## Author(s)

Stan Moore (Sandia National Laboratories)

## Backward Compatibility

Backward compatible. The change only affects output that was previously always `0` (or unrepresentable for large `cellID`), making it correct. Encoding now matches the existing decoder and the `pack_id` convention; no input syntax or file format changes.

## Implementation Notes

In each affected pack method, the integer branches now store the value bit-punned to match the decoder:

```cpp
buf[n] = ubuf(vector[i]).d;          // was: buf[n] = vector[i];
buf[n] = ubuf(array[i][icol]).d;     // was: buf[n] = array[i][icol];
buf[n] = ubuf(cells[icell].id).d;    // pack_cellid; was: buf[n] = cells[icell].id;
```

Correctness verified by building `spa_serial` and running:

- The issue reproducer (`custom surf create nstick int 0 set nstick v_ival all NULL`, `dump ... s_nstick`): now prints `s_nstick = 813` for all surfs, **byte-for-byte identical** to the reporter's reference `FIXED` output (was `0`).
- An analogous `custom grid ... int` dump: now prints the set value (was `0`).
- `dump particle ... cellID` with created particles: now prints real cell ids (was `0`).
- Regression: the surf reproducer continues to pass after all four fixes.

## Post Submission Checklist

- [x] The feature or features in this pull request is complete
- [ ] Suitable new documentation files and/or updates to the existing docs are included
- [ ] One or more example input decks are included
- [x] The source code follows the SPARTA formatting guidelines

## Further Information, Files, and Links

Original report and reproducer: sparta/sparta#640. The fix is a one-line change per integer branch in `src/dump_surf.cpp`, `src/dump_grid.cpp`, and `src/dump_particle.cpp`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01CP19ngSkuXbz8cv4kjjySx)_