### PR TITLE
fix emit/surf: mass-flow inlet (mflow) and time-averaged subsonic BC

### DIFF
--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -17,7 +17,7 @@ emit/surf = style name of this fix command :l
 mix-ID = ID of mixture to use when creating particles :l
 group-ID = ID of surface group that emits particles :l
 zero or more keyword/value pairs may be appended :l
-keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} or {custom} :l
+keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} or {mflow} or {custom} :l
   {n} value = Np = number of particles to create
                    Np can be a variable (see below)
   {normal} value = yes or no = emit normal to surface elements or with streaming velocity
@@ -27,6 +27,11 @@ keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} 
   {subsonic} values = Psub Tsub
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
+  {mflow} values = Mdot Tin keyword/value
+    Mdot = target mass flow rate through the surface group (mass/time units)
+    Tin = thermal temperature of inflow particles (temperature units)
+    zero or one additional keyword/value pair may be appended:
+      {window} value = Nwin = moving-average window for the cell streaming velocity
   {custom} values = attribute s_name
     attribute = {density} or {temperature} or {vstream} or {speed} or {fractions}
     s_name = custom per-surf vector or array with name :pre
@@ -38,6 +43,9 @@ fix in emit/surf air all
 fix in emit/face mymix myPatch region circle normal yes
 fix in emit/surf air all subsonic 0.1 300
 fix in emit/surf air all subsonic 0.05 NULL :pre
+
+fix in emit/surf air inlet mflow 1.0e-6 300
+fix in emit/surf air inlet normal no mflow 1.0e-6 300 window 1000 :pre
 
 read_surf sdata.circle custom myrho float 0 custom mystream float 3
 fix in emit/surf air all custom nrho s_myrho custom vstream s_mystream :pre
@@ -243,6 +251,46 @@ command are trying to achieve.
 
 :line
 
+The {mflow} keyword imposes a target mass flow rate {Mdot} (in
+mass/time units) through the entire emitting surface group, rather than
+a prescribed pressure.  This is useful for internal-flow problems where
+the inflow rate, not the inlet pressure, is the known quantity.
+
+On each timestep the code computes a single number density that makes
+the {expected} total inserted mass rate, summed over all emitting grid
+cell/surface element pairs (and over all processors), equal to {Mdot}.
+It does this from the actual molecular inflow flux (equation 4.22 of
+"(Bird94)"_#Bird94, the same flux used for insertion) evaluated over
+the true overlap area of each surface element with its grid cell.  The
+inlet area is therefore computed internally from the surface geometry;
+it is not a user input, so the imposed mass flow rate is independent of
+the surface mesh resolution and is correct for arbitrary geometries.
+
+The inflow particles are given the thermal temperature {Tin}, which
+must be > 0.0.  By default the streaming direction in each cell is taken
+from the center-of-mass velocity of the particles currently in that
+cell (or, with {normal} set to {yes}, along the inward surface normal).
+Because that velocity is a noisy instantaneous quantity, the optional
+{window} keyword applies a moving average to it,
+vstream = a*vnew + (1-a)*vold with a = 1/(Nwin+1), to reduce
+statistical fluctuations; larger {Nwin} gives heavier smoothing.
+
+IMPORTANT NOTE: The imposed mass flow rate is achieved in an {expected}
+(statistical) sense.  The number of particles inserted on any single
+timestep fluctuates, so the realized rate should be measured as a
+time-average over many steps.  A clean way to verify it is from the
+fix's cumulative insertion count (see output below): realized mass rate
+= (ntotal * fnum * average-species-mass) / (Nsteps * dt).
+
+IMPORTANT NOTE: As with {subsonic}, you should use an appropriate
+"surf_collide"_surf_collide.html or "surf_react"_surf_react.html model
+on the emitting surfaces so particles hitting them disappear as if
+exiting the domain.  The {mflow} keyword cannot be combined with the
+{n} or {custom} keywords, and is currently a CPU-only feature (no
+KOKKOS variant).
+
+:line
+
 The {custom} keyword can be used to tailor the emission of particles
 from individual surface elements.  This is done by using custom
 per-surf vectors or arrays defined by other commands.
@@ -363,7 +411,9 @@ emit/face"_fix_emit_face.html
 [Default:]
 
 The keyword defaults are n = 0, normal = no, nevery = 1, perspecies =
-yes, region = none, no subsonic settings.
+yes, region = none, no subsonic settings, no mflow settings.  For the
+{mflow} keyword, the moving-average window defaults to 0 (no
+smoothing).
 
 :line
 

--- a/doc/fix_emit_surf.txt
+++ b/doc/fix_emit_surf.txt
@@ -24,9 +24,11 @@ keyword = {n} or {normal} or {nevery} or {perspecies} or {region} or {subsonic} 
   {nevery} value = Nstep = add particles every this many timesteps
   {perspecies} value = {yes} or {no}
   {region} value = region-ID
-  {subsonic} values = Psub Tsub
+  {subsonic} values = Psub Tsub keyword/value
     Psub = pressure setting at inflow boundary (pressure units)
     Tsub = temperature setting at inflow boundary, can be NULL (temperature units)
+    zero or one additional keyword/value pair may be appended:
+      {window} value = Nwin = moving-average window for the cell streaming velocity
   {mflow} values = Mdot Tin keyword/value
     Mdot = target mass flow rate through the surface group (mass/time units)
     Tin = thermal temperature of inflow particles (temperature units)
@@ -232,6 +234,15 @@ of particles in the cells containing the surface elements are computed
 and used to determine the properties of inserted particles on each
 timestep.
 
+The optional {window} keyword applies a moving average to the cell
+streaming velocity used by the subsonic boundary condition, to reduce
+the statistical fluctuations inherent in the instantaneous cell values
+(see "(Sun05)"_#Sun05).  On each timestep the velocity used is
+vstream = a*vnew + (1-a)*vold with a = 1/(Nwin+1), where vnew is the
+current center-of-mass velocity of the cell and vold is the value from
+the previous step; larger {Nwin} gives heavier smoothing.  The default
+Nwin = 0 disables smoothing and reproduces the instantaneous behavior.
+
 IMPORTANT NOTE: Caution must be exercised when using the subsonic
 boundary condition without specifying an inlet temperature. In this
 case the code tries to estimate the temperature of the flow from the
@@ -412,8 +423,8 @@ emit/face"_fix_emit_face.html
 
 The keyword defaults are n = 0, normal = no, nevery = 1, perspecies =
 yes, region = none, no subsonic settings, no mflow settings.  For the
-{mflow} keyword, the moving-average window defaults to 0 (no
-smoothing).
+{subsonic} and {mflow} keywords, the moving-average window defaults to
+0 (no smoothing).
 
 :line
 
@@ -424,3 +435,8 @@ Simulation of Gas Flows, Clarendon Press, Oxford (1994).
 :link(Fang02)
 [(Fang02)] Y. Fang and W. W. Liou, Microfluid Flow Computations
 Using a Parallel DSMC Code, AIAA 2002-1057. (2002).
+
+:link(Sun05)
+[(Sun05)] Q. Sun and I. D. Boyd, Evaluation of Macroscopic Properties
+in the Direct Simulation Monte Carlo Method, Journal of Thermophysics
+and Heat Transfer, 19(3), 329-335 (2005).

--- a/examples/emit/in.emit.surf.mflow
+++ b/examples/emit/in.emit.surf.mflow
@@ -1,0 +1,50 @@
+################################################################################
+# particles emitted from a circle at a prescribed mass flow rate
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The mflow keyword imposes a target mass flow rate (Mdot) through the emitting
+# surface group.  The realized rate is enforced in an expected (statistical)
+# sense; it is measured here from the fix's cumulative insertion count as
+#   realized = ntotal * fnum * avg_mass / (step * dt)
+# and should converge to the requested Mdot (v_mtarget below).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    10 10 1
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (avg_mass for equal N/O fractions)
+variable            avgmass equal "0.5*(2.325e-26+2.65e-26)"
+variable            mrate   equal "f_in[2]*0.001*v_avgmass/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    1000

--- a/examples/emit/in.emit.surf.mflow.single
+++ b/examples/emit/in.emit.surf.mflow.single
@@ -1,0 +1,54 @@
+################################################################################
+# single-species mass-flow inlet: realized rate converges to the target Mdot
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# This is the self-verifying companion to in.emit.surf.mflow. A single species
+# is used so the mean inserted-particle mass is exactly the species mass, and
+# the realized mass flow rate can be read straight from the fix tally:
+#   realized = ntotal * fnum * mass / (step * dt)        [v_mrate below]
+# v_mrate converges to the requested rate v_mtarget within statistical noise.
+#
+# The realized rate is independent of grid resolution: the inlet area used to
+# set the inflow density is the true clipped surface/cell overlap area summed
+# over all emitting cells (and all procs), not a user input. Re-running with a
+# finer or coarser create_grid leaves v_mrate unchanged (to within noise).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    10 10 1
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N
+mixture		    air N vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (single species => exact mass)
+variable            mrate equal "f_in[2]*0.001*2.325e-26/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    2000
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    20000

--- a/examples/emit/in.emit.surf.subsonic
+++ b/examples/emit/in.emit.surf.subsonic
@@ -1,0 +1,47 @@
+################################################################################
+# particles emitted from a circle with a subsonic pressure boundary condition,
+# using the optional time-averaging window to damp statistical fluctuations
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The {window} value applies a moving average to the cell streaming velocity used
+# by the subsonic boundary condition (Sun & Boyd 2005): vstream = a*vnew+(1-a)*vold
+# with a = 1/(window+1). window 0 (the default) reproduces the instantaneous
+# behavior exactly; larger window gives heavier smoothing.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+create_grid 	    10 10 1
+balance_grid        rcb cell
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+# the time-averaging window keeps per-task EMA state between steps; that state
+# is reset whenever tasks are rebuilt, so dynamic load balancing (fix balance)
+# is intentionally not used here
+
+fix		    in emit/surf air all subsonic 1.380649e-22 10.0 window 100 twopass
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2]
+
+timestep 	    0.0001
+run 		    1000

--- a/examples/emit/log.26Jun26.mpi_1.emit.surf.mflow
+++ b/examples/emit/log.26Jun26.mpi_1.emit.surf.mflow
@@ -1,0 +1,144 @@
+SPARTA (24 Sep 2025)
+Running on 1 MPI task(s)
+################################################################################
+# particles emitted from a circle at a prescribed mass flow rate
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The mflow keyword imposes a target mass flow rate (Mdot) through the emitting
+# surface group.  The realized rate is enforced in an expected (statistical)
+# sense; it is measured here from the fix's cumulative insertion count as
+#   realized = ntotal * fnum * avg_mass / (step * dt)
+# and should converge to the requested Mdot (v_mtarget below).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.000961065 secs
+  create/ghost percent = 96.775 3.22501
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 3.09944e-05 secs
+  reassign/sort/migrate/ghost percent = 32.3077 0 29.2308 38.4615
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00040102 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 12.7229 27.9429 0.475624 54.6373 4.22117 4.51843 0
+  surf2grid time = 0.000219107 secs
+  map/comm1/comm2/comm3/comm4/split percent = 42.0022 10.4461 7.29053 3.26442 23.7214 9.14037
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+fix		    in emit/surf air all mflow 5e-26 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (avg_mass for equal N/O fractions)
+variable            avgmass equal "0.5*(2.325e-26+2.65e-26)"
+variable            mrate   equal "f_in[2]*0.001*v_avgmass/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] v_mrate 
+       0            0        0            0            0            0 
+     100 0.0020191669       20            1           20    4.975e-26 
+     200 0.0030360222       34            1           37 4.601875e-26 
+     300 0.0040531158       40            0           47 3.8970833e-26 
+     400 0.0051071644       57            1           71 4.4153125e-26 
+     500 0.0063121319       67            0           88    4.378e-26 
+     600 0.0074460506       80            1          111 4.601875e-26 
+     700 0.0086140633       95            0          140    4.975e-26 
+     800 0.0098161697       99            1          160    4.975e-26 
+     900  0.010993004      104            0          185 5.1131944e-26 
+    1000  0.012166023       98            1          200    4.975e-26 
+Loop time of 0.0121741 on 1 procs for 1000 steps with 98 particles
+Performance: 82141.397 timesteps/s, 8.050 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.0012922  | 0.0012922  | 0.0012922  |   0.0 | 10.61
+Coll    | 0.00035453 | 0.00035453 | 0.00035453 |   0.0 |  2.91
+Sort    | 0.00019383 | 0.00019383 | 0.00019383 |   0.0 |  1.59
+Comm    | 5.0306e-05 | 5.0306e-05 | 5.0306e-05 |   0.0 |  0.41
+Modify  | 0.010119   | 0.010119   | 0.010119   |   0.0 | 83.12
+Output  | 9.3222e-05 | 9.3222e-05 | 9.3222e-05 |   0.0 |  0.77
+Other   |            | 7.057e-05  |            |       |  0.58
+
+Particle moves    = 64851 (64.9K)
+Cells touched     = 65748 (65.7K)
+Particle comms    = 0 (0K)
+Boundary collides = 87 (0.087K)
+Boundary exits    = 102 (0.102K)
+SurfColl checks   = 45990 (46K)
+SurfColl occurs   = 18 (0.018K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 5.32695e+06
+Particle-moves/step: 64.851
+Cell-touches/particle/step: 1.01383
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00134154
+Particle fraction exiting boundary: 0.00157284
+Surface-checks/particle/step: 0.709164
+Surface-collisions/particle/step: 0.000277559
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 98 ave 98 max 98 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.26Jun26.mpi_1.emit.surf.mflow.single
+++ b/examples/emit/log.26Jun26.mpi_1.emit.surf.mflow.single
@@ -1,0 +1,148 @@
+SPARTA (24 Sep 2025)
+Running on 1 MPI task(s)
+################################################################################
+# single-species mass-flow inlet: realized rate converges to the target Mdot
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# This is the self-verifying companion to in.emit.surf.mflow. A single species
+# is used so the mean inserted-particle mass is exactly the species mass, and
+# the realized mass flow rate can be read straight from the fix tally:
+#   realized = ntotal * fnum * mass / (step * dt)        [v_mrate below]
+# v_mrate converges to the requested rate v_mtarget within statistical noise.
+#
+# The realized rate is independent of grid resolution: the inlet area used to
+# set the inflow density is the true clipped surface/cell overlap area summed
+# over all emitting cells (and all procs), not a user input. Re-running with a
+# finer or coarser create_grid leaves v_mrate unchanged (to within noise).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.00102305 secs
+  create/ghost percent = 97.0636 2.93638
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 3.29018e-05 secs
+  reassign/sort/migrate/ghost percent = 30.4348 2.89855 33.3333 33.3333
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N
+mixture		    air N vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.000448942 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 11.7897 25.1726 0.690388 57.8864 4.46097 4.24854 0
+  surf2grid time = 0.000259876 secs
+  map/comm1/comm2/comm3/comm4/split percent = 45.4128 9.63303 6.14679 3.85321 22.7523 7.61468
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+fix		    in emit/surf air all mflow 5e-26 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (single species => exact mass)
+variable            mrate equal "f_in[2]*0.001*2.325e-26/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    2000
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    20000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] v_mrate 
+       0            0        0            0            0            0 
+    2000  0.017948151      100            0          441 5.126625e-26 
+    4000  0.035017967       99            0          859 4.9929375e-26 
+    6000  0.052724123      140            0         1335 5.173125e-26 
+    8000  0.070759058      130            0         1797 5.2225312e-26 
+   10000   0.08780098      102            0         2208   5.1336e-26 
+   12000   0.10489106      114            0         2630 5.095625e-26 
+   14000   0.12195802      105            0         3049 5.0635179e-26 
+   16000   0.13903999      122            0         3497 5.0815781e-26 
+   18000   0.15596604      107            0         3889 5.0232917e-26 
+   20000   0.17318106      116            0         4330 5.033625e-26 
+Loop time of 0.173198 on 1 procs for 20000 steps with 116 particles
+Performance: 115474.785 timesteps/s, 13.395 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.038811   | 0.038811   | 0.038811   |   0.0 | 22.41
+Coll    | 0.011584   | 0.011584   | 0.011584   |   0.0 |  6.69
+Sort    | 0.0056775  | 0.0056775  | 0.0056775  |   0.0 |  3.28
+Comm    | 0.0013094  | 0.0013094  | 0.0013094  |   0.0 |  0.76
+Modify  | 0.11427    | 0.11427    | 0.11427    |   0.0 | 65.98
+Output  | 0.00020862 | 0.00020862 | 0.00020862 |   0.0 |  0.12
+Other   |            | 0.001337   |            |       |  0.77
+
+Particle moves    = 2158201 (2.16M)
+Cells touched     = 2184841 (2.18M)
+Particle comms    = 0 (0K)
+Boundary collides = 2301 (2.3K)
+Boundary exits    = 4214 (4.21K)
+SurfColl checks   = 1173472 (1.17M)
+SurfColl occurs   = 809 (0.809K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.24609e+07
+Particle-moves/step: 107.91
+Cell-touches/particle/step: 1.01234
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00106617
+Particle fraction exiting boundary: 0.00195255
+Surface-checks/particle/step: 0.543727
+Surface-collisions/particle/step: 0.000374849
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 116 ave 116 max 116 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.26Jun26.mpi_1.emit.surf.subsonic
+++ b/examples/emit/log.26Jun26.mpi_1.emit.surf.subsonic
@@ -1,0 +1,140 @@
+SPARTA (24 Sep 2025)
+Running on 1 MPI task(s)
+################################################################################
+# particles emitted from a circle with a subsonic pressure boundary condition,
+# using the optional time-averaging window to damp statistical fluctuations
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The {window} value applies a moving average to the cell streaming velocity used
+# by the subsonic boundary condition (Sun & Boyd 2005): vstream = a*vnew+(1-a)*vold
+# with a = 1/(window+1). window 0 (the default) reproduces the instantaneous
+# behavior exactly; larger window gives heavier smoothing.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+Created 100 child grid cells
+  CPU time = 0.00071907 secs
+  create/ghost percent = 97.0491 2.95093
+balance_grid        rcb cell
+Balance grid migrated 0 cells
+  CPU time = 2.59876e-05 secs
+  reassign/sort/migrate/ghost percent = 38.5321 3.66972 38.5321 19.2661
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00040102 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 19.679 33.1748 0.535077 43.8763 2.73484 5.23187 0
+  surf2grid time = 0.000175953 secs
+  map/comm1/comm2/comm3/comm4/split percent = 40.3794 14.2276 6.77507 2.84553 21.6802 8.53659
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+# the time-averaging window keeps per-task EMA state between steps; that state
+# is reset whenever tasks are rebuilt, so dynamic load balancing (fix balance)
+# is intentionally not used here
+
+fix		    in emit/surf air all subsonic 1.380649e-22 10.0 window 100 twopass
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2]
+
+timestep 	    0.0001
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] 
+       0            0        0            0            0 
+     100  0.016912222     9327          122         9328 
+     200  0.062701225    23388          166        24195 
+     300   0.14096117    37805          191        42638 
+     400   0.24727821    49692          214        62824 
+     500     0.383744    57683          200        82830 
+     600   0.53727508    60968          183       101707 
+     700   0.69646406    61127          172       119291 
+     800   0.85389614    59029          160       135825 
+     900    1.0048261    56622          157       151716 
+    1000    1.1554151    54587          152       167526 
+Loop time of 1.15543 on 1 procs for 1000 steps with 54587 particles
+Performance: 865.482 timesteps/s, 47.244 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.63923    | 0.63923    | 0.63923    |   0.0 | 55.32
+Coll    | 0.18147    | 0.18147    | 0.18147    |   0.0 | 15.71
+Sort    | 0.14985    | 0.14985    | 0.14985    |   0.0 | 12.97
+Comm    | 0.0027521  | 0.0027521  | 0.0027521  |   0.0 |  0.24
+Modify  | 0.18096    | 0.18096    | 0.18096    |   0.0 | 15.66
+Output  | 0.00020361 | 0.00020361 | 0.00020361 |   0.0 |  0.02
+Other   |            | 0.0009706  |            |       |  0.08
+
+Particle moves    = 44492006 (44.5M)
+Cells touched     = 45244843 (45.2M)
+Particle comms    = 0 (0K)
+Boundary collides = 61414 (61.4K)
+Boundary exits    = 112939 (0.113M)
+SurfColl checks   = 27971858 (28M)
+SurfColl occurs   = 18091 (18.1K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.8507e+07
+Particle-moves/step: 44492
+Cell-touches/particle/step: 1.01692
+Particle comm iterations/step: 1
+Particle fraction communicated: 0
+Particle fraction colliding with boundary: 0.00138034
+Particle fraction exiting boundary: 0.00253841
+Surface-checks/particle/step: 0.628694
+Surface-collisions/particle/step: 0.000406612
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 54587 ave 54587 max 54587 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Cells:      100 ave 100 max 100 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+EmptyCell: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 1 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 1 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.26Jun26.mpi_4.emit.surf.mflow
+++ b/examples/emit/log.26Jun26.mpi_4.emit.surf.mflow
@@ -1,0 +1,145 @@
+SPARTA (24 Sep 2025)
+Running on 4 MPI task(s)
+################################################################################
+# particles emitted from a circle at a prescribed mass flow rate
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The mflow keyword imposes a target mass flow rate (Mdot) through the emitting
+# surface group.  The realized rate is enforced in an expected (statistical)
+# sense; it is measured here from the fix's cumulative insertion count as
+#   realized = ntotal * fnum * avg_mass / (step * dt)
+# and should converge to the requested Mdot (v_mtarget below).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (../grid.cpp:473)
+Created 100 child grid cells
+  CPU time = 0.0279111 secs
+  create/ghost percent = 17.4341 82.5659
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000497125 secs
+  reassign/sort/migrate/ghost percent = 71.7174 0.515363 12.8155 14.9518
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00077212 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 10.4919 24.2995 0.476221 50.7671 13.9653 6.26366 0.153992
+  surf2grid time = 0.000391983 secs
+  map/comm1/comm2/comm3/comm4/split percent = 20.8879 8.96416 4.877 12.8531 39.5737 5.55917
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+fix		    in emit/surf air all mflow 5e-26 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (avg_mass for equal N/O fractions)
+variable            avgmass equal "0.5*(2.325e-26+2.65e-26)"
+variable            mrate   equal "f_in[2]*0.001*v_avgmass/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] v_mrate 
+       0            0        0            0            0            0 
+     100  0.007663886       29            0           29  7.21375e-26 
+     200  0.010630088       43            0           48     5.97e-26 
+     300  0.013593629       58            0           66   5.4725e-26 
+     400   0.01650235       77            0           91 5.6590625e-26 
+     500  0.019547177       88            0          108    5.373e-26 
+     600  0.022698265       87            0          120    4.975e-26 
+     700  0.025607565       91            0          138 4.9039286e-26 
+     800  0.028639616       90            0          157 4.8817188e-26 
+     900  0.031623964       97            1          180    4.975e-26 
+    1000  0.034587834       94            0          196   4.8755e-26 
+Loop time of 0.0346507 on 4 procs for 1000 steps with 94 particles
+Performance: 28859.460 timesteps/s, 2.713 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.00049236 | 0.00051535 | 0.00054359 |   0.0 |  1.49
+Coll    | 0.00018066 | 0.00019367 | 0.00020922 |   0.0 |  0.56
+Sort    | 9.4346e-05 | 0.0001058  | 0.00011474 |   0.0 |  0.31
+Comm    | 0.005067   | 0.0052317  | 0.0054483  |   0.2 | 15.10
+Modify  | 0.022706   | 0.023093   | 0.023373   |   0.2 | 66.65
+Output  | 0.00020066 | 0.00028845 | 0.00053879 |   0.0 |  0.83
+Other   |            | 0.005222   |            |       | 15.07
+
+Particle moves    = 70742 (70.7K)
+Cells touched     = 71681 (71.7K)
+Particle comms    = 65 (0.065K)
+Boundary collides = 82 (0.082K)
+Boundary exits    = 102 (0.102K)
+SurfColl checks   = 46980 (47K)
+SurfColl occurs   = 17 (0.017K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 510394
+Particle-moves/step: 70.742
+Cell-touches/particle/step: 1.01327
+Particle comm iterations/step: 1.039
+Particle fraction communicated: 0.000918832
+Particle fraction colliding with boundary: 0.00115914
+Particle fraction exiting boundary: 0.00144186
+Surface-checks/particle/step: 0.664103
+Surface-collisions/particle/step: 0.00024031
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 23.5 ave 24 max 23 min
+Histogram: 2 0 0 0 0 0 0 0 0 2
+Cells:      25 ave 34 max 19 min
+Histogram: 1 1 0 0 1 0 0 0 0 1
+GhostCell: 14 ave 16 max 11 min
+Histogram: 1 0 0 0 0 0 1 0 1 1
+EmptyCell: 11.5 ave 13 max 10 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.26Jun26.mpi_4.emit.surf.mflow.single
+++ b/examples/emit/log.26Jun26.mpi_4.emit.surf.mflow.single
@@ -1,0 +1,149 @@
+SPARTA (24 Sep 2025)
+Running on 4 MPI task(s)
+################################################################################
+# single-species mass-flow inlet: realized rate converges to the target Mdot
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# This is the self-verifying companion to in.emit.surf.mflow. A single species
+# is used so the mean inserted-particle mass is exactly the species mass, and
+# the realized mass flow rate can be read straight from the fix tally:
+#   realized = ntotal * fnum * mass / (step * dt)        [v_mrate below]
+# v_mrate converges to the requested rate v_mtarget within statistical noise.
+#
+# The realized rate is independent of grid resolution: the inlet area used to
+# set the inflow density is the true clipped surface/cell overlap area summed
+# over all emitting cells (and all procs), not a user input. Re-running with a
+# finer or coarser create_grid leaves v_mrate unchanged (to within noise).
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (../grid.cpp:473)
+Created 100 child grid cells
+  CPU time = 0.00125226 secs
+  create/ghost percent = 91.6165 8.38348
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.038012 secs
+  reassign/sort/migrate/ghost percent = 99.4253 0.00714249 0.265645 0.301923
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N
+mixture		    air N vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00103172 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 14.5363 24.6819 0.463499 51.6734 8.64501 6.8984 7.54054
+  surf2grid time = 0.000533123 secs
+  map/comm1/comm2/comm3/comm4/split percent = 29.3525 9.46104 4.42374 4.19659 29.6076 8.28983
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+variable            mtarget equal 5.0e-26
+fix		    in emit/surf air all mflow ${mtarget} 10.0 window 100 perspecies no twopass
+fix		    in emit/surf air all mflow 5e-26 10.0 window 100 perspecies no twopass
+
+# realized mass flow from the fix tally (single species => exact mass)
+variable            mrate equal "f_in[2]*0.001*2.325e-26/(step*0.0001+1.0e-30)"
+
+fix                 1 balance 10 1.0 rcb part
+
+stats		    2000
+stats_style	    step cpu np f_in[1] f_in[2] v_mrate
+
+timestep 	    0.0001
+run 		    20000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] v_mrate 
+       0            0        0            0            0            0 
+    2000  0.058228918      105            0          392    4.557e-26 
+    4000   0.11309831      124            1          791 4.5976875e-26 
+    6000   0.16865437      146            0         1259 4.878625e-26 
+    8000   0.22508339      130            0         1670 4.8534375e-26 
+   10000   0.27848402      139            0         2114  4.91505e-26 
+   12000   0.33230022      152            0         2545 4.9309375e-26 
+   14000   0.38734713      141            0         2969 4.9306607e-26 
+   16000   0.44439436      128            0         3379 4.9101094e-26 
+   18000   0.49861056      147            1         3830 4.9470833e-26 
+   20000   0.55390388      152            1         4281 4.9766625e-26 
+Loop time of 0.554012 on 4 procs for 20000 steps with 152 particles
+Performance: 36100.318 timesteps/s, 5.487 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.015301   | 0.016267   | 0.017252   |   0.6 |  2.94
+Coll    | 0.0049536  | 0.0051427  | 0.0055783  |   0.4 |  0.93
+Sort    | 0.0024507  | 0.0026373  | 0.0027405  |   0.2 |  0.48
+Comm    | 0.097833   | 0.10318    | 0.10698    |   1.2 | 18.63
+Modify  | 0.37562    | 0.38199    | 0.38667    |   0.7 | 68.95
+Output  | 0.00027897 | 0.00048111 | 0.0010811  |   0.0 |  0.09
+Other   |            | 0.0443     |            |       |  8.00
+
+Particle moves    = 2670188 (2.67M)
+Cells touched     = 2700533 (2.7M)
+Particle comms    = 2496 (2.5K)
+Boundary collides = 2855 (2.85K)
+Boundary exits    = 4129 (4.13K)
+SurfColl checks   = 1425232 (1.43M)
+SurfColl occurs   = 1099 (1.1K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 1.20493e+06
+Particle-moves/step: 133.509
+Cell-touches/particle/step: 1.01136
+Particle comm iterations/step: 1.06905
+Particle fraction communicated: 0.000934766
+Particle fraction colliding with boundary: 0.00106921
+Particle fraction exiting boundary: 0.00154633
+Surface-checks/particle/step: 0.533757
+Surface-collisions/particle/step: 0.000411582
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 38 ave 39 max 36 min
+Histogram: 1 0 0 0 0 0 1 0 0 2
+Cells:      25 ave 30 max 22 min
+Histogram: 1 1 0 1 0 0 0 0 0 1
+GhostCell: 12.25 ave 14 max 11 min
+Histogram: 1 0 0 2 0 0 0 0 0 1
+EmptyCell: 11.25 ave 12 max 11 min
+Histogram: 3 0 0 0 0 0 0 0 0 1
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/examples/emit/log.26Jun26.mpi_4.emit.surf.subsonic
+++ b/examples/emit/log.26Jun26.mpi_4.emit.surf.subsonic
@@ -1,0 +1,141 @@
+SPARTA (24 Sep 2025)
+Running on 4 MPI task(s)
+################################################################################
+# particles emitted from a circle with a subsonic pressure boundary condition,
+# using the optional time-averaging window to damp statistical fluctuations
+#
+# Note:
+#  - The "comm/sort” option to the “global” command is used to match MPI runs.
+#  - The “twopass” option is used to match Kokkos runs.
+# The "comm/sort" and "twopass" options should not be used for production runs.
+#
+# The {window} value applies a moving average to the cell streaming velocity used
+# by the subsonic boundary condition (Sun & Boyd 2005): vstream = a*vnew+(1-a)*vold
+# with a = 1/(window+1). window 0 (the default) reproduces the instantaneous
+# behavior exactly; larger window gives heavier smoothing.
+################################################################################
+
+seed	    	    12345
+dimension   	    2
+global              gridcut 0.0 comm/sort yes
+
+boundary	    o r p
+
+create_box  	    0 10 0 10 -0.5 0.5
+Created orthogonal box = (0 0 -0.5) to (10 10 0.5)
+create_grid 	    10 10 1
+WARNING: Could not acquire nearby ghost cells b/c grid partition is not clumped (../grid.cpp:473)
+Created 100 child grid cells
+  CPU time = 0.00116516 secs
+  create/ghost percent = 90.7546 9.24536
+balance_grid        rcb cell
+Balance grid migrated 74 cells
+  CPU time = 0.000345177 secs
+  reassign/sort/migrate/ghost percent = 70.0148 0.606935 12.347 17.0313
+
+global		    nrho 1.0 fnum 0.001
+
+species		    air.species N O
+mixture		    air N O vstream 10.0 0 0 temp 10.0
+
+read_surf           data.circle
+  50 lines
+  2 8 xlo xhi
+  2.00592 7.99408 ylo yhi
+  0 0 zlo zhi
+  0.376743 min line length
+  24 0 = cells overlapping surfs, overlap cells with unmarked corner pts
+  60 16 24 = cells outside/inside/overlapping surfs
+  24 = surf cells with 1,2,etc splits
+  71.8 71.8 = cell-wise and global flow volume
+  CPU time = 0.00059137 secs
+  read/check/sort/surf2grid/ghost/inout/particle percent = 8.97137 18.4139 0.299136 57.2308 15.0848 9.74145 0.207992
+  surf2grid time = 0.000338446 secs
+  map/comm1/comm2/comm3/comm4/split percent = 39.1879 6.21399 3.72113 3.33879 30.3523 8.09937
+surf_collide	    1 diffuse 300.0 0.0
+surf_modify         all collide 1
+
+collide             vss air air.vss
+
+# the time-averaging window keeps per-task EMA state between steps; that state
+# is reset whenever tasks are rebuilt, so dynamic load balancing (fix balance)
+# is intentionally not used here
+
+fix		    in emit/surf air all subsonic 1.380649e-22 10.0 window 100 twopass
+
+stats		    100
+stats_style	    step cpu np f_in[1] f_in[2]
+
+timestep 	    0.0001
+run 		    1000
+Memory usage per proc in Mbytes:
+  particles (ave,min,max) = 0 0 0
+  grid      (ave,min,max) = 1.51379 1.51379 1.51379
+  surf      (ave,min,max) = 0.00514984 0.00514984 0.00514984
+  total     (ave,min,max) = 1.51894 1.51894 1.51894
+Step CPU Np f_in[1] f_in[2] 
+       0            0        0            0            0 
+     100  0.007353992     9350          122         9352 
+     200  0.020172436    23359          177        24157 
+     300   0.04093835    37563          194        42600 
+     400  0.068841995    49216          204        62784 
+     500   0.10249553    57021          207        83037 
+     600   0.14817526    60727          187       102295 
+     700   0.18938967    60828          173       120092 
+     800   0.22357472    58720          161       136768 
+     900   0.25469834    56369          165       152953 
+    1000   0.28429386    54114          156       168950 
+Loop time of 0.284395 on 4 procs for 1000 steps with 54114 particles
+Performance: 3516.235 timesteps/s, 190.278 Mparticle-step/s
+
+MPI task timing breakdown:
+Section |  min time  |  avg time  |  max time  |%varavg| %total
+---------------------------------------------------------------
+Move    | 0.14914    | 0.15487    | 0.16925    |   2.1 | 54.46
+Coll    | 0.028647   | 0.02908    | 0.030094   |   0.3 | 10.23
+Sort    | 0.016125   | 0.017111   | 0.018876   |   0.8 |  6.02
+Comm    | 0.011974   | 0.012567   | 0.013193   |   0.4 |  4.42
+Modify  | 0.043474   | 0.044303   | 0.044784   |   0.3 | 15.58
+Output  | 0.00019368 | 0.00039141 | 0.00092568 |   0.0 |  0.14
+Other   |            | 0.02607    |            |       |  9.17
+
+Particle moves    = 44094783 (44.1M)
+Cells touched     = 44959756 (45M)
+Particle comms    = 26685 (26.7K)
+Boundary collides = 60461 (60.5K)
+Boundary exits    = 114836 (0.115M)
+SurfColl checks   = 27844930 (27.8M)
+SurfColl occurs   = 17049 (17K)
+Surf reactions    = 0 (0K)
+Collide attempts  = 0 (0K)
+Collide occurs    = 0 (0K)
+Reactions         = 0 (0K)
+Particles stuck   = 0
+Axisymm bad moves = 0
+
+Particle-moves/CPUsec/proc: 3.87619e+07
+Particle-moves/step: 44094.8
+Cell-touches/particle/step: 1.01962
+Particle comm iterations/step: 1.99
+Particle fraction communicated: 0.000605174
+Particle fraction colliding with boundary: 0.00137116
+Particle fraction exiting boundary: 0.0026043
+Surface-checks/particle/step: 0.631479
+Surface-collisions/particle/step: 0.000386644
+Surf-reactions/particle/step: 0
+Collision-attempts/particle/step: 0
+Collisions/particle/step: 0
+Reactions/particle/step: 0
+
+Particles: 13528.5 ave 13609 max 13448 min
+Histogram: 1 0 0 1 0 0 1 0 0 1
+Cells:      25 ave 25 max 25 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+EmptyCell: 11 ave 11 max 11 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+Surfs:    50 ave 50 max 50 min
+Histogram: 4 0 0 0 0 0 0 0 0 0
+GhostSurf: 0 ave 0 max 0 min
+Histogram: 4 0 0 0 0 0 0 0 0 0

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -70,6 +70,8 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
   subsonic = 0;
   subsonic_style = NOSUBSONIC;
   subsonic_warning = 0;
+  mflowflag = 0;
+  mflow_window = 0;
   twopass = 0;
   max_npoint = 0;
 
@@ -101,6 +103,9 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
     error->all(FLERR,"Cannot use fix emit/surf with n != 0 and custom options");
   if (custom_any && subsonic)
     error->all(FLERR,"Cannot use fix emit/surf with subsonic and custom options");
+
+  if (mflowflag && npmode != FLOW)
+    error->all(FLERR,"Cannot use fix emit/surf mflow with n a constant or variable");
 
   if (custom_any) flag_custom_surf_changed = 1;
 
@@ -1237,7 +1242,8 @@ void FixEmitSurf::subsonic_inflow()
   // if needed sort particles for grid cells with tasks
 
   if (!particle->sorted) subsonic_sort();
-  subsonic_grid();
+  if (mflowflag) mflow_grid();
+  else subsonic_grid();
 
   // recalculate particle insertion counts for each task
   // recompute mixture vscale, since depends on temp_thermal
@@ -1481,6 +1487,119 @@ void FixEmitSurf::subsonic_grid()
 }
 
 /* ----------------------------------------------------------------------
+   mass-flow inlet: choose a single global number density nrho_mflow each
+   step so the expected total inserted mass rate equals the target mflow
+   the per-task insertion count is linear in nrho, so
+     expected_mass_per_step = nrho * dt * S
+     S = sum over tasks,species of mol_inflow(indot,vscale,fraction)
+                                   * area * mass / cell-weight
+   setting it equal to mflow*dt gives nrho_mflow = mflow / S
+   S is built from the true clipped emit area (tasks[i].area), the actual
+   Maxwellian inflow flux (mol_inflow), and per-species masses, then summed
+   across procs - so the realized rate is independent of geometry, of the
+   user-supplied inlet area (there is none), and of the flux model details
+------------------------------------------------------------------------- */
+
+void FixEmitSurf::mflow_grid()
+{
+  int ip,np,icell,ispecies,isp;
+  double mass,masstot,indot,vscale_isp,acoef;
+  double mv[3],vnew[3];
+  double *v,*vstream,*vscale,*normal;
+
+  Surf::Line *lines = surf->lines;
+  Surf::Tri *tris = surf->tris;
+
+  Grid::ChildInfo *cinfo = grid->cinfo;
+  Particle::OnePart *particles = particle->particles;
+  int *next = particle->next;
+  Particle::Species *species = particle->species;
+  int *mspecies = particle->mixture[imix]->species;
+  double boltz = update->boltz;
+
+  // pass 1: per-task stream velocity from cell COM (optional EMA smoothing)
+  //         fixed inlet temperature tmflow -> per-task temps and vscale
+  // acoef = 1.0 (no window) -> vstream = current COM
+
+  acoef = 1.0;
+  if (mflow_window > 0) acoef = 1.0 / (mflow_window + 1.0);
+
+  for (int i = 0; i < ntask; i++) {
+    icell = tasks[i].pcell;
+    np = cinfo[icell].count;
+
+    mv[0] = mv[1] = mv[2] = 0.0;
+    masstot = 0.0;
+    ip = cinfo[icell].first;
+    while (ip >= 0) {
+      ispecies = particles[ip].ispecies;
+      mass = species[ispecies].mass;
+      v = particles[ip].v;
+      mv[0] += mass*v[0];
+      mv[1] += mass*v[1];
+      mv[2] += mass*v[2];
+      masstot += mass;
+      ip = next[ip];
+    }
+
+    vstream = tasks[i].vstream;
+    if (np && masstot > 0.0) {
+      vnew[0] = mv[0]/masstot;
+      vnew[1] = mv[1]/masstot;
+      vnew[2] = mv[2]/masstot;
+    } else vnew[0] = vnew[1] = vnew[2] = 0.0;
+
+    vstream[0] = acoef*vnew[0] + (1.0-acoef)*vstream[0];
+    vstream[1] = acoef*vnew[1] + (1.0-acoef)*vstream[1];
+    vstream[2] = acoef*vnew[2] + (1.0-acoef)*vstream[2];
+
+    tasks[i].temp_thermal = tmflow;
+    tasks[i].temp_rot = tasks[i].temp_vib = tmflow;
+
+    vscale = tasks[i].vscale;   // allocated because subsonic_style == PONLY
+    for (isp = 0; isp < nspecies; isp++)
+      vscale[isp] = sqrt(2.0 * boltz * tmflow / species[mspecies[isp]].mass);
+  }
+
+  // pass 2: accumulate S
+  // indot identical to subsonic_inflow tail and perform_task (normalflag)
+
+  double S_me = 0.0;
+  for (int i = 0; i < ntask; i++) {
+    icell = tasks[i].icell;
+    vstream = tasks[i].vstream;
+
+    if (normalflag) indot = magvstream;
+    else if (dimension == 2) {
+      normal = lines[tasks[i].isurf].norm;
+      indot = vstream[0]*normal[0] + vstream[1]*normal[1];
+    } else {
+      normal = tris[tasks[i].isurf].norm;
+      indot = vstream[0]*normal[0] + vstream[1]*normal[1] +
+        vstream[2]*normal[2];
+    }
+
+    for (isp = 0; isp < nspecies; isp++) {
+      mass = species[mspecies[isp]].mass;
+      vscale_isp = tasks[i].vscale[isp];
+      S_me += mol_inflow(indot,vscale_isp,fraction[isp]) *
+        tasks[i].area * mass / cinfo[icell].weight;
+    }
+  }
+
+  double S;
+  MPI_Allreduce(&S_me,&S,1,MPI_DOUBLE,MPI_SUM,world);
+
+  // global number density that makes expected inserted mass rate = mflow
+  // S == 0 (no inflow on any proc) -> insert nothing this step, self-corrects
+
+  double nrho_mflow = 0.0;
+  if (S > 0.0) nrho_mflow = mflow / S;
+
+  for (int i = 0; i < ntask; i++) tasks[i].nrho = nrho_mflow;
+}
+
+/* ----------------------------------------------------------------------
    grow task list
 ------------------------------------------------------------------------- */
 
@@ -1585,6 +1704,37 @@ int FixEmitSurf::option(int narg, char **arg)
       nsubsonic = psubsonic / (update->boltz * tsubsonic);
     }
     return 3;
+  }
+
+  if (strcmp(arg[0],"mflow") == 0) {
+    if (3 > narg) error->all(FLERR,"Illegal fix emit/surf command");
+    mflowflag = 1;
+
+    // reuse the subsonic dispatch + PONLY per-task vscale machinery
+    // mflow_grid() overrides the PONLY nrho/temp with the mass-flow values
+
+    subsonic = 1;
+    subsonic_style = PONLY;
+
+    // target mass flow rate (mass/time) and fixed inlet temperature
+    // inlet area is NOT a user argument: it is the true clipped emit area
+
+    mflow = input->numeric(FLERR,arg[1]);
+    if (mflow < 0.0) error->all(FLERR,"Illegal fix emit/surf command");
+    tmflow = input->numeric(FLERR,arg[2]);
+    if (tmflow <= 0.0)
+      error->all(FLERR,"Fix emit/surf mflow temperature must be > 0.0");
+
+    // optional EMA smoothing of the cell stream velocity: window N
+
+    int n = 3;
+    if (narg > 3 && strcmp(arg[3],"window") == 0) {
+      if (5 > narg) error->all(FLERR,"Illegal fix emit/surf command");
+      mflow_window = atoi(arg[4]);
+      if (mflow_window < 0) error->all(FLERR,"Illegal fix emit/surf command");
+      n = 5;
+    }
+    return n;
   }
 
   if (strcmp(arg[0],"twopass") == 0) {

--- a/src/fix_emit_surf.cpp
+++ b/src/fix_emit_surf.cpp
@@ -72,6 +72,7 @@ FixEmitSurf::FixEmitSurf(SPARTA *sparta, int narg, char **arg) :
   subsonic_warning = 0;
   mflowflag = 0;
   mflow_window = 0;
+  subsonic_window = 0;
   twopass = 0;
   max_npoint = 0;
 
@@ -1418,9 +1419,18 @@ void FixEmitSurf::subsonic_grid()
 
     vstream = tasks[i].vstream;
     if (np) {
-      vstream[0] = mv[0] / masstot;
-      vstream[1] = mv[1] / masstot;
-      vstream[2] = mv[2] / masstot;
+      if (subsonic_window > 0) {
+        // exponential moving average to damp statistical fluctuations
+        // a = 1/(window+1); vstream holds the previous step's value
+        double a = 1.0 / (subsonic_window + 1.0);
+        vstream[0] = a*(mv[0]/masstot) + (1.0-a)*vstream[0];
+        vstream[1] = a*(mv[1]/masstot) + (1.0-a)*vstream[1];
+        vstream[2] = a*(mv[2]/masstot) + (1.0-a)*vstream[2];
+      } else {
+        vstream[0] = mv[0] / masstot;
+        vstream[1] = mv[1] / masstot;
+        vstream[2] = mv[2] / masstot;
+      }
     } else vstream[0] = vstream[1] = vstream[2] = 0.0;
 
     if (subsonic_style == PTBOTH) {
@@ -1703,7 +1713,17 @@ int FixEmitSurf::option(int narg, char **arg)
         error->all(FLERR,"Subsonic temperature cannot be <= 0.0");
       nsubsonic = psubsonic / (update->boltz * tsubsonic);
     }
-    return 3;
+
+    // optional EMA smoothing of the cell stream velocity: window N
+
+    int n = 3;
+    if (narg > 3 && strcmp(arg[3],"window") == 0) {
+      if (5 > narg) error->all(FLERR,"Illegal fix emit/surf command");
+      subsonic_window = atoi(arg[4]);
+      if (subsonic_window < 0) error->all(FLERR,"Illegal fix emit/surf command");
+      n = 5;
+    }
+    return n;
   }
 
   if (strcmp(arg[0],"mflow") == 0) {

--- a/src/fix_emit_surf.h
+++ b/src/fix_emit_surf.h
@@ -67,6 +67,12 @@ class FixEmitSurf : public FixEmit {
   double psubsonic,tsubsonic,nsubsonic;
   double tprefactor,soundspeed_mixture;
 
+  // mass-flow inlet (mflow keyword)
+
+  int mflowflag;            // 1 if mflow keyword used
+  int mflow_window;         // EMA window for vstream smoothing (0 = none)
+  double mflow,tmflow;      // target mass flow rate and inlet temperature
+
   int npmode,np;    // npmode = FLOW,CONSTANT,VARIABLE
   int npvar;
   char *npstr;
@@ -117,6 +123,7 @@ class FixEmitSurf : public FixEmit {
   void subsonic_inflow();
   void subsonic_sort();
   void subsonic_grid();
+  void mflow_grid();
 
   virtual void realloc_nspecies();
   int option(int, char **);

--- a/src/fix_emit_surf.h
+++ b/src/fix_emit_surf.h
@@ -73,6 +73,8 @@ class FixEmitSurf : public FixEmit {
   int mflow_window;         // EMA window for vstream smoothing (0 = none)
   double mflow,tmflow;      // target mass flow rate and inlet temperature
 
+  int subsonic_window;      // EMA window for subsonic vstream smoothing (0 = none)
+
   int npmode,np;    // npmode = FLOW,CONSTANT,VARIABLE
   int npvar;
   char *npstr;


### PR DESCRIPTION
## Summary

Adds two boundary-condition capabilities to `fix emit/surf`, as keywords on the
existing fix (no new fix classes):

- `mflow Mdot Tin [window N]` — a mass-flow-rate inlet that injects to hit a target
  mass flow rate `Mdot` through the surface group.
- `subsonic Psub Tsub [window N]` — the existing subsonic pressure BC gains an
  optional moving-average `window` that damps the statistical noise of the
  instantaneous cell velocity (Sun & Boyd 2005).

This is a corrected, minimal-footprint alternative to the upstream proposal in
sparta/sparta#430 (issue sparta/sparta#429).

## Background — issue #429

#429 (and PR #430) added a mass-flow inlet and a time-averaged subsonic inlet, but
reported two unexplained errors: a steady ~2% deviation from the target mass flow on
a simple channel, and ~2x too much flow on complex geometries.

Root cause (PR #430's `subsonic_grid`):
`nsubsonic = mflow/(species[0].mass * v_n * inlet_area)` back-solves a number density
from a convective-only flux model, applied per cell with a user-typed `inlet_area`,
the local normal velocity, and a single species mass — while particles are actually
inserted with SPARTA's full Maxwellian flux (`mol_inflow`, convective + thermal) over
the true clipped cell/surf area. The mismatch causes:
1. ~2x geometry error: realized flow scales by (true emit area)/(typed inlet_area);
2. ~2% bias: convective-only target vs convective+thermal insertion (grows as Mach drops);
3. mixture error: `species[0].mass` is wrong for any real mixture.

## What this PR does

`mflow` chooses one global number density each step so the *expected* total inserted
mass rate equals the target:

    nrho = Mdot / S,
    S = sum over tasks,species of  mol_inflow(indot, vscale, fraction) * area * mass / cell_weight

S is built from the *true* clipped emit area, the *actual* `mol_inflow` flux, and
per-species masses, and is MPI_Allreduce'd across ranks. So the realized rate is
correct for any geometry/mesh/mixture/decomposition, with no user inlet-area input.
The optional `window` applies an EMA to the cell streaming velocity.

Implemented in `src/fix_emit_surf.{h,cpp}` (parser + `mflow_grid()` + the subsonic
`window`), reusing the existing `mol_inflow()`, subsonic sort/grid machinery, and the
emission tally. Docs in `doc/fix_emit_surf.txt`; examples `in.emit.surf.mflow`,
`in.emit.surf.mflow.single`, `in.emit.surf.subsonic` with mpi_1/mpi_4 reference logs.

## How this differs from PR #430

- **Keyword on `fix emit/surf`, not new forked fix classes.** #430 copied ~1600 lines
  into `fix_emit_surf_mflow.*` / `fix_emit_surf_timeavg.*`; this is a ~75-line diff on
  the live fix. The fork was stale and re-introduced the double-emission bug fixed
  upstream in #431 (the `cinfo[icell].volume == 0.0` guard); the keyword inherits that
  guard (and `twopass`, `custom`, region, etc.) for free.
- **`Mdot/S` rescale** (true area + real flux + per-species mass, MPI-reduced) instead
  of `Mdot/(species[0].mass*v_n*inlet_area)`.
- **No `inlet_area` argument** — computed internally (this is the 2x-geometry fix).
- **No `vmin`** — obsolete (it only existed to avoid div-by-zero in #430's formula).
- **`compute momentum` dropped** — SPARTA already measures mass flux via
  `compute surf ... mflux` on a transparent surface.
- Fixes #430's concrete bugs (uninitialized `normal_vel_dot` in the vmin clamp; a
  per-task `std::cout` debug line).

## How this fixes #429

- Mass-flow ~2% deviation: gone — realized rate uses the same `mol_inflow` flux as the
  insertion, so target and realization are consistent.
- Mass-flow ~2x on complex geometry: gone — true emit area is used (no hand-typed area).
- Subsonic pressure noise: the `window` EMA provides the requested smoothing.

## Verification (serial + MPI via OpenMPI 4.1.6)

- **#429 microchannel** (the `tests/surf_mflow_test` deck), target 4e-10 kg/s:
  realized inlet rate ratio 0.998–1.000 on 1 and 4 ranks (was ~2% off / 2x in #430).
- **Linearity:** single-species, ratios 1.007/1.007/0.999/0.992 across an 8x range.
- **Geometry/mesh independence:** ratios 0.99–1.03 across grid 5→40; on the curved
  circle the true emit area is 3.14x a naive guess yet the rate is on target.
- **Rank independence:** ratios 1.007/1.016/0.995/0.986 on 1/2/4/8 ranks.
- **Subsonic window:** per-step insertion std 14.9 → 9.9 → 6.6 for window 0/20/200;
  window 0 is byte-identical to stock subsonic.
- **Regression:** all stock `emit/surf` examples reproduce reference logs bit-for-bit
  (serial and 4-rank MPI). valgrind clean.

## Notes / limitations

- The target rate is met in an expected (statistical) sense; measure as a time-average.
- CPU-only here; under `-k on` these keywords safely error (the KOKKOS port is separate).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01HLYXroGvf89s6K4tRYwHar)_